### PR TITLE
Simplify the networking code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+.DS_Store
+
 ## Build generated
 build/
 DerivedData

--- a/Common/Operations/DownloadOperation.swift
+++ b/Common/Operations/DownloadOperation.swift
@@ -33,11 +33,15 @@ class DownloadOperation: Operation {
             print(">>> downloadTask task for \(self.request.url) is complete. <<<")
             //print(">>> downloadTask: {\nlocation: \(location),\nresponse: \(response),\nerror: \(error)\n} <<<")
             
-            if self.isCancelled { return }
+            if self.isCancelled {
+                disGroup.leave()
+                return
+            }
             
             if let err = error {
                 let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .unknown(err.localizedDescription))
                 self.error = apiError
+                disGroup.leave()
                 return
             }
             
@@ -45,12 +49,14 @@ class DownloadOperation: Operation {
             guard let location = location else {
                 let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .downloadedLocationIsMissing)
                 self.error = apiError
+                disGroup.leave()
                 return
             }
             
             guard let dataFromLocation = try? Data(contentsOf: location) else {
                 let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .couldNotCreateDataFromDownloadedFile)
                 self.error = apiError
+                disGroup.leave()
                 return
             }
             

--- a/Common/Operations/Nightscout.swift
+++ b/Common/Operations/Nightscout.swift
@@ -249,7 +249,7 @@ public extension Site {
         return NightscoutDownloader.sharedInstance
     }
     
-    public func fetchDataFromNetwork(userInitiated: Bool = false, completion:@escaping (_ updatedSite: Site, _ error: NightscoutRESTClientError?) -> Void) {
+    public func fetchDataFromNetwork(completion:@escaping (_ updatedSite: Site, _ error: NightscoutRESTClientError?) -> Void) {
         
         var updatedSite = self
         

--- a/Common/Operations/Nightscout.swift
+++ b/Common/Operations/Nightscout.swift
@@ -16,7 +16,7 @@ extension String {
     }
 }
 
-fileprivate let API_DOMAIN = "com.Nightscout.RESTClient"
+private let API_DOMAIN = "com.Nightscout.RESTClient"
 
 public struct NightscoutRESTClientError: Error {
     /// The domain of the error.
@@ -50,30 +50,7 @@ public struct NightscoutRESTClientError: Error {
 internal protocol NightscouterOperation {
     var data: Data? { set get }
     var error: NightscoutRESTClientError? { set get }
-    
-    func parse(JSONData data: Data)
 }
-
-public class NightscouterBaseOperation: Operation, NightscouterOperation {
-    internal var data: Data?
-    internal var error: NightscoutRESTClientError?
-    
-    public override func main() {
-        
-        if self.isCancelled { return }
-        
-        guard let data = self.data, self.error == nil else {
-            fatalError()
-        }
-        
-        parse(JSONData: data)
-    }
-    
-    internal func parse(JSONData data: Data) {
-        
-    }
-}
-
 
 public protocol NightscoutDownloaderDelegate {
     func nightscout(_ downloader: NightscoutDownloader, didEndWithError error: NightscoutRESTClientError?)
@@ -86,31 +63,28 @@ public class NightscoutDownloader {
 
     static var sharedInstance: NightscoutDownloader = NightscoutDownloader()
 
-    let processingQueue: OperationQueue = OperationQueue()
+    private let processingQueue: OperationQueue = OperationQueue()
     
     
     // MARK: - Private Variables
 
-    fileprivate lazy var session: URLSession = {
+    private lazy var session: URLSession = {
         return URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: self.processingQueue)
     }()
     
-    fileprivate var userInitiated: Bool = false
-    fileprivate var hostURL: URL? = nil
-    fileprivate var apiSecret: String? = nil
+    private var hostURL: URL? = nil
+    private var apiSecret: String? = nil
     
     private enum APIRoutes: String {
-        case status, entries, pebble, devicestatus, cal
+        case status,
+        entries,
+        devicestatus
     }
 
     
     // MARK: - Private Methods
     
-    fileprivate func generateConfigurationRequestHeader(forAPIRoute APIRoute: APIRoutes = .status) -> URLRequest? {
-        
-        guard let url = self.hostURL else {
-            return nil
-        }
+    private func urlRequest(forAPIRoute APIRoute: APIRoutes = .status, url: URL) -> URLRequest {
         
         var headers = [String: String]()
         // Set the headers.
@@ -119,49 +93,28 @@ public class NightscoutDownloader {
         // 2. Provide the API key, passphrase or api-secret token. User of the api prvides a string and this will convert to a SHA1 string.
         headers["api-secret"] = apiSecret?.sha1()
         
-        var requestURL: URL
-        
         let pathExtension = "json"
         
         let apiVersion = "api/v1"
+
+        var requestURL = url.appendingPathComponent("\(apiVersion)/\(APIRoute.rawValue)").appendingPathExtension(pathExtension)
         
-        switch APIRoute {
-        case .entries:
+        if APIRoute == .entries {
             let entryCount = 300
-            let queryItemCount = URLQueryItem(name: "count", value: "\(entryCount)")
-            var comps = URLComponents(url: url.appendingPathComponent("\(apiVersion)/\(APIRoute.rawValue)").appendingPathExtension(pathExtension) , resolvingAgainstBaseURL: true)
-            comps!.queryItems = [queryItemCount]
+            let countQueryItem = URLQueryItem(name: "count", value: "\(entryCount)")
+            var comps = URLComponents(url: requestURL, resolvingAgainstBaseURL: true)
+            comps!.queryItems = [countQueryItem]
             requestURL = comps!.url!
-            
-        case .cal:
-            requestURL = url.appendingPathComponent("\(apiVersion)/\(APIRoutes.entries.rawValue)").appendingPathComponent(APIRoute.rawValue).appendingPathExtension(pathExtension)
-        case .pebble:
-            requestURL = url.appendingPathComponent(APIRoute.rawValue).appendingPathExtension(pathExtension)
-            
-        case .devicestatus:
-            requestURL = url.appendingPathComponent("\(apiVersion)/\(APIRoute.rawValue)").appendingPathExtension(pathExtension)
-        default:
-            requestURL = url.appendingPathComponent("\(apiVersion)/\(APIRoute.rawValue)").appendingPathExtension(pathExtension)
         }
-        
+
         var request = URLRequest(url: requestURL)
         
         for (headerField, headerValue) in headers {
             request.setValue(headerValue, forHTTPHeaderField: headerField)
         }
         
-        //request.networkServiceType = userInitiated ? .default : .background
-
         return request
     }
-    
-      // Request JSON data for the Site's configuration.
-    var configurationRequest: URLRequest { return self.generateConfigurationRequestHeader(forAPIRoute: .status)! }
-    
-    var downloadReadingsRequest: URLRequest { return self.generateConfigurationRequestHeader(forAPIRoute: .entries)! }
-
-    var requestDevice: URLRequest { return self.generateConfigurationRequestHeader(forAPIRoute: .devicestatus)! }
-
     
     // MARK: - Public Methods
     
@@ -169,15 +122,13 @@ public class NightscoutDownloader {
         processingQueue.name = API_DOMAIN
     }
     
-    
-    // Need to wrap this up into a new class and an Operation block, that can be canceled as well as monitored.
-    public func networkRequest(forNightscoutURL url: URL, apiPassword password: String? = nil, userInitiated: Bool = false, completion:@escaping (_ configuration: ServerConfiguration?,_ sensorGlucoseValues: [SensorGlucoseValue]?, _ calibrations: [Calibration]?, _ meteredGlucoseValues:[MeteredGlucoseValue]?, _ deviceStatus: [DeviceStatus]?, _ error: NightscoutRESTClientError?) -> Void) {
+    //TODO: Need to wrap this up into a new class and an Operation block, that can be canceled as well as monitored.
+    public func networkRequest(forNightscoutURL url: URL, apiPassword password: String? = nil, completion:@escaping (_ configuration: ServerConfiguration?,_ sensorGlucoseValues: [SensorGlucoseValue]?, _ calibrations: [Calibration]?, _ meteredGlucoseValues:[MeteredGlucoseValue]?, _ deviceStatus: [DeviceStatus]?, _ error: NightscoutRESTClientError?) -> Void) {
         
         print(">>> Entering \(#function) for \(url) <<<")
         
         self.hostURL = url
         self.apiSecret = password
-        self.userInitiated = userInitiated
         
         var configuration: ServerConfiguration?
         var sgvs: [SensorGlucoseValue]?
@@ -190,10 +141,12 @@ public class NightscoutDownloader {
         var serverConfigError: NightscoutRESTClientError?
         var deviceError: NightscoutRESTClientError?
         
-        let fetchConfig = DownloadOperation(withURLRequest: configurationRequest)
+        // set up the config request chain
+        let configRequest = urlRequest(forAPIRoute: .status, url: url)
+        let fetchConfig = DownloadOperation(withURLRequest: configRequest)
         let parseConfig = ParseConfigurationOperation()
         let configAdaptor = BlockOperation {
-            parseConfig.data  = fetchConfig.data
+            parseConfig.data = fetchConfig.data
             parseConfig.error = fetchConfig.error
         }
         
@@ -216,10 +169,12 @@ public class NightscoutDownloader {
         processingQueue.addOperation(configAdaptor)
         processingQueue.addOperation(parseConfig)
         
+        // Set up the entries request chain
+        let downloadReadingsRequest = urlRequest(forAPIRoute: .entries, url: url)
         let fetchEntries = DownloadOperation(withURLRequest: downloadReadingsRequest)
         let parseEntries = ParseReadingsOperation()
         let entriesAdaptor = BlockOperation {
-            parseEntries.data  = fetchEntries.data
+            parseEntries.data = fetchEntries.data
             parseEntries.error = fetchEntries.error
         }
         
@@ -244,11 +199,12 @@ public class NightscoutDownloader {
         processingQueue.addOperation(entriesAdaptor)
         processingQueue.addOperation(parseEntries)
         
-        
+        // Set up the device request chain
+        let requestDevice = urlRequest(forAPIRoute: .devicestatus, url: url)
         let fetchDevice = DownloadOperation(withURLRequest: requestDevice)
         let parseDevice = ParseDeviceStatusOperation()
         let deviceAdaptor = BlockOperation {
-            parseDevice.data  = fetchDevice.data
+            parseDevice.data = fetchDevice.data
             parseDevice.error = fetchDevice.error
         }
         
@@ -293,11 +249,11 @@ public extension Site {
         return NightscoutDownloader.sharedInstance
     }
     
-    public func fetchDataFromNetwrok(userInitiated: Bool = false, completion:@escaping (_ updatedSite: Site, _ error: NightscoutRESTClientError?) -> Void) {
+    public func fetchDataFromNetwork(userInitiated: Bool = false, completion:@escaping (_ updatedSite: Site, _ error: NightscoutRESTClientError?) -> Void) {
         
         var updatedSite = self
         
-        nightscouterAPI.networkRequest(forNightscoutURL: self.url, apiPassword: self.apiSecret, userInitiated: userInitiated) { (config, sgvs, cals, mbgs, devices, err) in
+        nightscouterAPI.networkRequest(forNightscoutURL: self.url, apiPassword: self.apiSecret) { (config, sgvs, cals, mbgs, devices, err) in
             
             if let error = err {
                 print(error.kind)

--- a/Common/Operations/ParseConfigurationOperation.swift
+++ b/Common/Operations/ParseConfigurationOperation.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
-public class ParseConfigurationOperation: NightscouterBaseOperation {
-    
+public class ParseConfigurationOperation: Operation, NightscouterOperation {
+
+    internal var error: NightscoutRESTClientError?
+    internal var data: Data?
     var configuration: ServerConfiguration?
     
     public convenience init(withJSONData data: Data?) {
@@ -18,8 +20,8 @@ public class ParseConfigurationOperation: NightscouterBaseOperation {
         self.data = data
     }
     
-    override func parse(JSONData data: Data?) {
-        
+    public override func main() {
+
         guard let data = data, let stringVersion = String(data: data, encoding: String.Encoding.utf8) else {
             let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .couldNotCreateDataFromDownloadedFile)
             self.error = apiError

--- a/Common/Operations/ParseDeviceStatusOperation.swift
+++ b/Common/Operations/ParseDeviceStatusOperation.swift
@@ -8,7 +8,10 @@
 
 import Foundation
 
-public class ParseDeviceStatusOperation: NightscouterBaseOperation {
+public class ParseDeviceStatusOperation: Operation, NightscouterOperation {
+    
+    internal var error: NightscoutRESTClientError?
+    internal var data: Data?
     
     var deviceStatus: [DeviceStatus] = []
     
@@ -17,9 +20,13 @@ public class ParseDeviceStatusOperation: NightscouterBaseOperation {
         self.name = "Parse JSON for Nightscout Device Status"
         self.data = data
     }
-    
-    override func parse(JSONData data: Data) {
-        super.parse(JSONData: data)
+
+    public override func main() {
+        guard let data = data else {
+            print("We expect data to be set at this point in the NightscouterOperation")
+            return
+        }
+        
         guard let stringVersion = String(data: data, encoding: String.Encoding.utf8) else {
             let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .couldNotCreateDataFromDownloadedFile)
             self.error = apiError

--- a/Common/Operations/ParseReadingsOperation.swift
+++ b/Common/Operations/ParseReadingsOperation.swift
@@ -8,8 +8,11 @@
 
 import Foundation
 
-public class ParseReadingsOperation: NightscouterBaseOperation {
+public class ParseReadingsOperation: Operation, NightscouterOperation {
     
+    internal var error: NightscoutRESTClientError?
+    internal var data: Data?
+
     var sensorGlucoseValues: [SensorGlucoseValue] = []
     var calibrations: [Calibration] = []
     var meteredGlucoseValues: [MeteredGlucoseValue] = []
@@ -24,8 +27,7 @@ public class ParseReadingsOperation: NightscouterBaseOperation {
         self.data = data
     }
     
-    override func parse(JSONData data: Data?) {
-
+    public override func main() {
         guard let data = data, let stringVersion = String(data: data, encoding: String.Encoding.utf8) else {
             let apiError = NightscoutRESTClientError(line: #line, column: #column, kind: .couldNotCreateDataFromDownloadedFile)
             self.error = apiError

--- a/Common/Protocols/UpdatableUserInterfaceType.swift
+++ b/Common/Protocols/UpdatableUserInterfaceType.swift
@@ -24,13 +24,13 @@ import Foundation
 public protocol UpdatableUserInterfaceType {
     func startUpdateUITimer()
     var updateInterval: TimeInterval { get }
-    func updateUI(notif: Timer?)
+    func updateUI()
 }
 
 public extension UpdatableUserInterfaceType where Self: ViewController {
     
     var updateUITimer: Timer {
-        return Timer.scheduledTimer(timeInterval: updateInterval, target: self, selector: #selector(Self.updateUI(notif:)), userInfo: nil, repeats: true)
+        return Timer.scheduledTimer(timeInterval: updateInterval, target: self, selector: #selector(updateUI), userInfo: nil, repeats: true)
     }
     
     func startUpdateUITimer() {

--- a/Common/Stores/SiteStoreTypeProtocols.swift
+++ b/Common/Stores/SiteStoreTypeProtocols.swift
@@ -79,12 +79,13 @@ public protocol SiteStoreType {
     /// - returns Bool: True if things were successful.
     ///
     func clearAllSites() -> Bool
+    
     ///
     /// Save all site data to long-term storage.
-    /// -returns Bool: True if things were successful.
+    /// If the save fails we print and forcefully quit the app
     ///
-    @discardableResult
-    func saveData(_ dictionary: [String: Any]) -> (savedLocally: Bool, updatedApplicationContext: Bool)
+    func saveData(_ dictionary: [String: Any])
+    
     ///
     /// Load all site data from long-term storage
     /// -returns Bool: True if things were successful.

--- a/Common/Stores/SitesDataSource.swift
+++ b/Common/Stores/SitesDataSource.swift
@@ -292,8 +292,7 @@ public class SitesDataSource: SiteStoreType {
         
     }
     
-    @discardableResult
-    public func saveData(_ dictionary: [String: Any]) -> (savedLocally: Bool, updatedApplicationContext: Bool) {
+    public func saveData(_ dictionary: [String: Any]) {
         
         var dictionaryToSend = dictionary
         
@@ -319,9 +318,13 @@ public class SitesDataSource: SiteStoreType {
         if successfullAppContextUpdate {
             successfullSave = defaults.synchronize()
             delayDataUpdateNotification()
+        } else {
+            fatalError("Unable to update the app context \(self)")
         }
         
-        return (successfullSave, successfullAppContextUpdate)
+        if successfullSave == false {
+            fatalError("Unable to save Data")
+        }
     }
     
     var delayDataUpdateNotification: (()->()) {

--- a/Nightscouter/AppDelegate.swift
+++ b/Nightscouter/AppDelegate.swift
@@ -64,7 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SitesDataSourceProvider, 
         SitesDataSource.sharedInstance.appIsInBackground = true
         
         sites.forEach { (site) in
-            site.fetchDataFromNetwrok(userInitiated: true, completion: { (updatedSite, error) in
+            site.fetchDataFromNetwork(userInitiated: true, completion: { (updatedSite, error) in
                 SitesDataSource.sharedInstance.updateSite(updatedSite)
             })
         }

--- a/Nightscouter/AppDelegate.swift
+++ b/Nightscouter/AppDelegate.swift
@@ -64,7 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SitesDataSourceProvider, 
         SitesDataSource.sharedInstance.appIsInBackground = true
         
         sites.forEach { (site) in
-            site.fetchDataFromNetwork(userInitiated: true, completion: { (updatedSite, error) in
+            site.fetchDataFromNetwork(completion: { (updatedSite, error) in
                 SitesDataSource.sharedInstance.updateSite(updatedSite)
             })
         }

--- a/Nightscouter/SiteDetailViewController.swift
+++ b/Nightscouter/SiteDetailViewController.swift
@@ -141,35 +141,30 @@ extension SiteDetailViewController {
     
     func updateSite(_ notification: Notification?) {
         print(">>> Entering \(#function) <<<")
-        self.updateData(forceUpdate: true)
+        self.updateData()
     }
     
-    func updateData(forceUpdate force: Bool = false) {
+    func updateData() {
         guard let site = self.site else { return }
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
-        if (site.updateNow || site.sgvs.isEmpty || force == true) {
-            UIApplication.shared.isNetworkActivityIndicatorVisible = true
-            
-            self.siteActivityView?.startAnimating()
-            site.fetchDataFromNetwork(userInitiated: force) { (updatedSite, err) in
-                if let _ = err {
-                    DispatchQueue.main.async {
-                        // self.presentAlertDialog(site.url, index: index, error: error.kind.description)
-                    }
-                    return
-                }
-                
-                SitesDataSource.sharedInstance.updateSite(updatedSite)
-                self.site = updatedSite
-                
+        self.siteActivityView?.startAnimating()
+        site.fetchDataFromNetwork() { (updatedSite, err) in
+            if let _ = err {
                 DispatchQueue.main.async {
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                    self.siteActivityView?.stopAnimating()
-                    self.updateUI()
+                    // self.presentAlertDialog(site.url, index: index, error: error.kind.description)
                 }
+                return
             }
-        } else {
-            self.updateUI()
+            
+            SitesDataSource.sharedInstance.updateSite(updatedSite)
+            self.site = updatedSite
+            
+            DispatchQueue.main.async {
+                UIApplication.shared.isNetworkActivityIndicatorVisible = false
+                self.siteActivityView?.stopAnimating()
+                self.updateUI()
+            }
         }
     }
     

--- a/Nightscouter/SiteDetailViewController.swift
+++ b/Nightscouter/SiteDetailViewController.swift
@@ -114,11 +114,11 @@ extension SiteDetailViewController {
         if #available(iOS 10.0, *) {
             self.timer = Timer.scheduledTimer(withTimeInterval: TimeInterval.OneMinute, repeats: true, block: { (timer) in
                 DispatchQueue.main.async {
-                    self.updateUI(timer: timer)
+                    self.updateUI()
                 }
             })
         } else {
-            self.timer = Timer.scheduledTimer(timeInterval: TimeInterval.OneMinute, target: self, selector: #selector(SiteListTableViewController.updateUI(timer:)), userInfo: nil, repeats: true)
+            self.timer = Timer.scheduledTimer(timeInterval: TimeInterval.OneMinute, target: self, selector: #selector(SiteListTableViewController.updateUI), userInfo: nil, repeats: true)
         }
         
         setupNotifications()
@@ -132,7 +132,7 @@ extension SiteDetailViewController {
         
         NotificationCenter.default.addObserver(forName: .NightscoutAlarmNotification, object: nil, queue: .main) { (notif) in
             if (notif.object as? AlarmObject) != nil {
-                self.updateUI(timer: nil)
+                self.updateUI()
             }
         }
         //NotificationCenter.default.addObserver(self, selector: #selector(SiteListTableViewController.updateData), name: .NightscoutDataUpdatedNotification, object: nil)
@@ -168,13 +168,12 @@ extension SiteDetailViewController {
         }
     }
     
-    func updateUI(timer: Timer? = nil) {
+    func updateUI() {
         guard let site = site else {
             return
         }
         configureView(withSite: site)
     }
-    
     
     @IBAction func unwindToSiteDetail(_ segue:UIStoryboardSegue) {
         // print(">>> Entering \(#function) <<<")

--- a/Nightscouter/SiteDetailViewController.swift
+++ b/Nightscouter/SiteDetailViewController.swift
@@ -151,7 +151,7 @@ extension SiteDetailViewController {
             UIApplication.shared.isNetworkActivityIndicatorVisible = true
             
             self.siteActivityView?.startAnimating()
-            site.fetchDataFromNetwrok(userInitiated: force) { (updatedSite, err) in
+            site.fetchDataFromNetwork(userInitiated: force) { (updatedSite, err) in
                 if let _ = err {
                     DispatchQueue.main.async {
                         // self.presentAlertDialog(site.url, index: index, error: error.kind.description)

--- a/Nightscouter/SiteListTableViewController.swift
+++ b/Nightscouter/SiteListTableViewController.swift
@@ -288,23 +288,23 @@ class SiteListTableViewController: UITableViewController, SitesDataSourceProvide
         refreshControl?.tintColor = UIColor.white
         refreshControl?.layer.zPosition = tableView.backgroundView!.layer.zPosition + 1
         
-        updateUI(timer: nil)
+        updateUI()
         
         if #available(iOS 10.0, *) {
             self.timer = Timer.scheduledTimer(withTimeInterval: TimeInterval.OneMinute, repeats: true, block: { (timer) in
                 DispatchQueue.main.async {
-                    self.updateUI(timer: timer)
+                    self.updateUI()
                 }
             })
         } else {
-            self.timer = Timer.scheduledTimer(timeInterval: TimeInterval.OneMinute, target: self, selector: #selector(SiteListTableViewController.updateUI(timer:)), userInfo: nil, repeats: true)
+            self.timer = Timer.scheduledTimer(timeInterval: TimeInterval.OneMinute, target: self, selector: #selector(updateUI), userInfo: nil, repeats: true)
         }
         
         // Make sure the idle screen timer is turned back to normal. Screen will time out.
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
-    func updateUI(timer: Timer?) {
+    func updateUI() {
         print(">>> Entering \(#function) <<<")
         print("Updating user interface at: \(Date())")
         self.tableView.reloadData()
@@ -353,7 +353,7 @@ class SiteListTableViewController: UITableViewController, SitesDataSourceProvide
         
         NotificationCenter.default.addObserver(forName: .NightscoutAlarmNotification, object: nil, queue: .main) { (notif) in
             if (notif.object as? AlarmObject) != nil {
-                self.updateUI(timer: nil)
+                self.updateUI()
             }
         }
         //NotificationCenter.default.addObserver(self, selector: #selector(SiteListTableViewController.updateData), name: .NightscoutDataUpdatedNotification, object: nil)

--- a/Nightscouter/SiteListTableViewController.swift
+++ b/Nightscouter/SiteListTableViewController.swift
@@ -366,7 +366,7 @@ class SiteListTableViewController: UITableViewController, SitesDataSourceProvide
         
         cell.configure(withDataSource: model, delegate: model)
         // FIXME:// this prevents a loop, but needs to be fixed and errors need to be reported.
-         if site.updateNow && date.timeIntervalSinceNow < TimeInterval.FourMinutes.inThePast {
+        if site.updateNow && date.timeIntervalSinceNow < TimeInterval.FourMinutes.inThePast {
             refreshDataFor(site, index: indexPath.row)
         }
     }
@@ -412,7 +412,7 @@ class SiteListTableViewController: UITableViewController, SitesDataSourceProvide
         
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
-        site.fetchDataFromNetwrok(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
             if let error = err {
                 OperationQueue.main.addOperation {
                     self.presentAlertDialog(site.url, index: index, error: error.kind.description)

--- a/Nightscouter/SiteListTableViewController.swift
+++ b/Nightscouter/SiteListTableViewController.swift
@@ -406,13 +406,13 @@ class SiteListTableViewController: UITableViewController, SitesDataSourceProvide
         }
     }
     
-    func refreshDataFor(_ site: Site, index: Int, userInitiated: Bool = false){
+    func refreshDataFor(_ site: Site, index: Int){
         /// Tie into networking code.
         FIXME()
         
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
-        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork() { (updatedSite, err) in
             if let error = err {
                 OperationQueue.main.addOperation {
                     self.presentAlertDialog(site.url, index: index, error: error.kind.description)

--- a/NightscouterNow Extension/ExtensionDelegate.swift
+++ b/NightscouterNow Extension/ExtensionDelegate.swift
@@ -75,7 +75,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
                 group.enter()
                 for site in SitesDataSource.sharedInstance.sites {
                     group.enter()
-                    site.fetchDataFromNetwrok(completion: { (updatedSite, error) in
+                    site.fetchDataFromNetwork(completion: { (updatedSite, error) in
                         SitesDataSource.sharedInstance.updateSite(updatedSite)
                         group.leave()
                     })

--- a/NightscouterNow Extension/GlanceController.swift
+++ b/NightscouterNow Extension/GlanceController.swift
@@ -35,7 +35,7 @@ class GlanceController: WKInterfaceController {
         beginGlanceUpdates()
         //Update data.
         FIXME()
-        SitesDataSource.sharedInstance.primarySite?.fetchDataFromNetwork(userInitiated: true, completion: { (updateSite, error) in
+        SitesDataSource.sharedInstance.primarySite?.fetchDataFromNetwork(completion: { (updateSite, error) in
             
             SitesDataSource.sharedInstance.updateSite(updateSite)
 

--- a/NightscouterNow Extension/GlanceController.swift
+++ b/NightscouterNow Extension/GlanceController.swift
@@ -35,7 +35,7 @@ class GlanceController: WKInterfaceController {
         beginGlanceUpdates()
         //Update data.
         FIXME()
-        SitesDataSource.sharedInstance.primarySite?.fetchDataFromNetwrok(userInitiated: true, completion: { (updateSite, error) in
+        SitesDataSource.sharedInstance.primarySite?.fetchDataFromNetwork(userInitiated: true, completion: { (updateSite, error) in
             
             SitesDataSource.sharedInstance.updateSite(updateSite)
 

--- a/NightscouterNow Extension/SiteDetailInterfaceController.swift
+++ b/NightscouterNow Extension/SiteDetailInterfaceController.swift
@@ -57,7 +57,7 @@ class SiteDetailInterfaceController: WKInterfaceController {
     func refreshDataFor(_ site: Site, index: Int = 0, userInitiated: Bool = false) {
         print(">>> Entering \(#function) <<<")
         /// Tie into networking code.
-        site.fetchDataFromNetwrok(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
             if let _ = err {
                 return
             }

--- a/NightscouterNow Extension/SiteDetailInterfaceController.swift
+++ b/NightscouterNow Extension/SiteDetailInterfaceController.swift
@@ -51,13 +51,13 @@ class SiteDetailInterfaceController: WKInterfaceController {
         print(">>> Entering \(#function) <<<")
 
         guard let site = site else { return }
-        refreshDataFor(site, userInitiated: true)
+        refreshDataFor(site)
     }
     
-    func refreshDataFor(_ site: Site, index: Int = 0, userInitiated: Bool = false) {
+    func refreshDataFor(_ site: Site, index: Int = 0) {
         print(">>> Entering \(#function) <<<")
         /// Tie into networking code.
-        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork() { (updatedSite, err) in
             if let _ = err {
                 return
             }

--- a/NightscouterNow Extension/SitesTableInterfaceController.swift
+++ b/NightscouterNow Extension/SitesTableInterfaceController.swift
@@ -115,15 +115,15 @@ class SitesTableInterfaceController: WKInterfaceController, SitesDataSourceProvi
     @IBAction func updateButton() {
         print(">>> Entering \(#function) <<<")
         for (index, site) in self.sites.enumerated() {
-            self.refreshDataFor(site, index: index, userInitiated: true)
+            self.refreshDataFor(site, index: index)
         }
     }
     
-    func refreshDataFor(_ site: Site, index: Int, userInitiated: Bool = false) {
+    func refreshDataFor(_ site: Site, index: Int) {
         print(">>> Entering \(#function) <<<")
         /// Tie into networking code.
         currentlyUpdating = true
-        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork() { (updatedSite, err) in
             
             self.currentlyUpdating = false
             if let error = err {

--- a/NightscouterNow Extension/SitesTableInterfaceController.swift
+++ b/NightscouterNow Extension/SitesTableInterfaceController.swift
@@ -123,7 +123,7 @@ class SitesTableInterfaceController: WKInterfaceController, SitesDataSourceProvi
         print(">>> Entering \(#function) <<<")
         /// Tie into networking code.
         currentlyUpdating = true
-        site.fetchDataFromNetwrok(userInitiated: userInitiated) { (updatedSite, err) in
+        site.fetchDataFromNetwork(userInitiated: userInitiated) { (updatedSite, err) in
             
             self.currentlyUpdating = false
             if let error = err {

--- a/NightscouterToday/TodayViewController.swift
+++ b/NightscouterToday/TodayViewController.swift
@@ -148,7 +148,7 @@ class TodayViewController: UITableViewController, NCWidgetProviding, SitesDataSo
     func refreshDataFor(_ site: Site, index: Int){
         // Start up the API
         FIXME()
-        site.fetchDataFromNetwrok(userInitiated: true) { (updatedSite, err) in
+        site.fetchDataFromNetwork() { (updatedSite, err) in
             if let _ = err {
                 return
             }


### PR DESCRIPTION
A few easy wins to simplify and make more readable
the networking code:
- Remove the NightsscouterBaseOperation as it
  doesn’t provide any more information than
  the NightscouterOperation protocol
- Simplify our use of optionals. In many cases
  we know that we will get what we are asking
  for. In cases where we didn't know, perfer
  a guard and no action rather than the `?` and `!` dance.
- Remove pebble and cal from the `APIRoutes`
  as they were never called. Doing this
  allowed us to simplify the switch on
  the endpoint. All of the options do
  nearly the same thing
- Remove `userInitiated` for network
  requests as it was never used
  and shouldn't really matter
- file private -> private in NightScout.swift
