### PR TITLE
Changed required fields for Medtronic compatibility

### DIFF
--- a/Common/Operations/ParseReadingsOperation.swift
+++ b/Common/Operations/ParseReadingsOperation.swift
@@ -18,7 +18,7 @@ public class ParseReadingsOperation: Operation, NightscouterOperation {
     var meteredGlucoseValues: [MeteredGlucoseValue] = []
     
     fileprivate enum SupportedEntryTypes: String {
-        case sgv, mbg, cal
+        case sgv, mbg, cal, pumpdata
     }
     
     public convenience init(withJSONData data: Data?) {
@@ -63,6 +63,8 @@ public class ParseReadingsOperation: Operation, NightscouterOperation {
                     if let cal = Calibration.decode(entry) {
                         calibrations.append(cal)
                     }
+                case .pumpdata:
+                    continue
                 }
             }
             

--- a/Common/Parsers/JSONParser.swift
+++ b/Common/Parsers/JSONParser.swift
@@ -372,20 +372,24 @@ extension SensorGlucoseValue: Encodable, Decodable {
     public static func decode(_ dict: [String : Any]) -> SensorGlucoseValue? {
         let json = dict
         
-        guard let deviceString = json[JSONKey.device] as? String, let mgdl = json[JSONKey.mgdl] as? Double, let mill = json[JSONKey.mills] as? Double, let directionString = json[JSONKey.direction] as? String else {
+        guard let deviceString = json[JSONKey.device] as? String, let mgdl = json[JSONKey.mgdl] as? Double, let mill = json[JSONKey.mills] as? Double else {
             return nil
         }
         
+        var directionString = json[JSONKey.direction] as? String
         let filtered = json[JSONKey.filtered] as? Double ?? 0
         let noiseInt = json[JSONKey.noise] as? Int ?? 0
         let rssi = json[JSONKey.rssi] as? Int ?? 0
         let unfiltered = json[JSONKey.unfiltered] as? Double ?? 0
         
         let device = Device(rawValue: deviceString) ?? .unknown
-        let direction = Direction(rawValue: directionString) ?? .none
+        if (directionString == nil) {
+            directionString = "None"
+        }
+        let direction = Direction(rawValue: directionString!)
         let noise = Noise(rawValue: noiseInt) ?? .unknown
 
-        return SensorGlucoseValue(direction: direction, device: device, rssi: rssi, unfiltered: unfiltered, filtered: filtered, mgdl: mgdl, noise: noise, milliseconds: mill)
+        return SensorGlucoseValue(direction: direction!, device: device, rssi: rssi, unfiltered: unfiltered, filtered: filtered, mgdl: mgdl, noise: noise, milliseconds: mill)
     }
 }
 

--- a/Common/Parsers/JSONParser.swift
+++ b/Common/Parsers/JSONParser.swift
@@ -386,10 +386,10 @@ extension SensorGlucoseValue: Encodable, Decodable {
         if (directionString == nil) {
             directionString = "None"
         }
-        let direction = Direction(rawValue: directionString!)
+        let direction = Direction(rawValue: directionString!)!
         let noise = Noise(rawValue: noiseInt) ?? .unknown
 
-        return SensorGlucoseValue(direction: direction!, device: device, rssi: rssi, unfiltered: unfiltered, filtered: filtered, mgdl: mgdl, noise: noise, milliseconds: mill)
+        return SensorGlucoseValue(direction: direction, device: device, rssi: rssi, unfiltered: unfiltered, filtered: filtered, mgdl: mgdl, noise: noise, milliseconds: mill)
     }
 }
 


### PR DESCRIPTION
I'm running a purely Medtronic setup, and the JSON objects returned from NS don't have some of the fields that Dexcom uses, so the code fails to retrieve the information properly.

I'm not the best Swift programmer, especially when it comes to question marks, so I'm sure there's a Swiftier way to handle this, but it does work for me as-is.

Also, can't test it with a Dexcom setup.